### PR TITLE
Feature/1 serve command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,6 @@ notify = "8.2.0"
 pulldown-cmark = "0.13.0"
 serde = { version = "1.0.228", features = ["derive"] }
 tera = "1.20.1"
+tiny_http = "0.12.0"
 toml = "0.9.10"
 walkdir = "2.5.0"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -113,10 +113,10 @@ impl Cli {
                 }
                 Ok(())
             }
-            Command::Serve { host, port, watch } => {
-                let _cfg = crate::config::Config::load(&root, config_path.as_deref())?;
-                let _ = (host, port, watch);
-                bail!("serve is not implemented yet")
+            Command::Serve { host, port, watch: _ } => {
+                let cfg = crate::config::Config::load(&root, config_path.as_deref())?;
+                // serve は dist を配るので、build 済み前提（なければ serve.rs でエラー）
+                crate::serve::serve_dist(&cfg, &host, port)
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod config;
 mod cli;
 mod site;
 mod build;
+mod serve;
 
 fn main() -> error::Result<()> {
     let cli = cli::Cli::parse();

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -1,0 +1,82 @@
+use anyhow::{bail, Context};
+use std::fs;
+use std::io::Cursor;
+use std::path::{Path, PathBuf};
+
+use crate::config::Config;
+use crate::error::Result;
+
+pub fn serve_dist(cfg: &Config, host: &str, port: u16) -> Result<()> {
+    if !cfg.output_dir.exists() {
+        bail!(
+            "output_dir not found: {} (run `oxidepress build` first)",
+            cfg.output_dir.display()
+        );
+    }
+
+    let addr = format!("{host}:{port}");
+    let server = tiny_http::Server::http(&addr)
+        .map_err(|e| anyhow::anyhow!("failed to bind http server: {addr}: {e}"))?;
+
+    eprintln!("Serving {} at http://{addr}", cfg.output_dir.display());
+
+    for request in server.incoming_requests() {
+        let url = request.url();
+        let file_path = resolve_path(&cfg.output_dir, url);
+
+        match file_to_response(&file_path) {
+            Ok(resp) => {
+                let _ = request.respond(resp);
+            }
+            Err(_) => {
+                let resp = tiny_http::Response::from_string("Not Found").with_status_code(404);
+                let _ = request.respond(resp);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn resolve_path(dist: &Path, url: &str) -> PathBuf {
+    let mut p = url.trim_start_matches('/').to_string();
+
+    if p.is_empty() {
+        return dist.join("index.html");
+    }
+
+    if p.ends_with('/') {
+        p.push_str("index.html");
+        return dist.join(p);
+    }
+
+    let candidate_dir_index = dist.join(&p).join("index.html");
+    if !p.contains('.') && candidate_dir_index.exists() {
+        return candidate_dir_index;
+    }
+
+    dist.join(p)
+}
+
+fn file_to_response(path: &Path) -> Result<tiny_http::Response<Cursor<Vec<u8>>>> {
+    let data = fs::read(path).with_context(|| format!("failed to read {}", path.display()))?;
+    let mut resp = tiny_http::Response::from_data(data);
+
+    if let Some(ext) = path.extension().and_then(|s| s.to_str()) {
+        let ct = match ext {
+            "html" => "text/html; charset=utf-8",
+            "css" => "text/css; charset=utf-8",
+            "js" => "application/javascript; charset=utf-8",
+            "json" => "application/json; charset=utf-8",
+            "svg" => "image/svg+xml",
+            "png" => "image/png",
+            "jpg" | "jpeg" => "image/jpeg",
+            _ => "application/octet-stream",
+        };
+        resp = resp.with_header(
+            tiny_http::Header::from_bytes("Content-Type", ct).expect("valid header"),
+        );
+    }
+
+    Ok(resp)
+}

--- a/src/site/mod.rs
+++ b/src/site/mod.rs
@@ -58,6 +58,10 @@ impl Site {
 }
 
 fn to_output_path(out_dir: &Path, rel_md: &Path) -> PathBuf {
+    if rel_md == Path::new("index.md") {
+        return out_dir.join("index.html");
+    }
+    
     let mut rel = rel_md.to_path_buf();
     rel.set_extension(""); // a.md -> a
     // a -> a/index.html


### PR DESCRIPTION
## Title / タイトル
[EN] Align build output for root index with serve routing
[JP] ルートインデックスのビルド出力をサーブルーティングに合わせて調整する
---

## Overview / 概要
[EN]
This PR implements a minimal serve command to serve the built dist directory over HTTP, and aligns the build output so that content/index.md is generated as dist/index.html for correct root URL handling.
 
[JP]
この PR では、ビルド済みの dist ディレクトリをローカル HTTP サーバで配信する最小限の serve コマンドを実装し、トップページが / で正しく表示されるよう content/index.md の出力先を dist/index.html に修正しました。

---

## Type / 種類
<!-- 該当するものを残す -->
- Feature

---

## Changes / 変更内容
[EN] List key changes
- Add minimal static file server for dist directory using tiny_http
- Implement basic URL-to-file resolution (/, /foo/, /foo/index.html)
- Fix build output so root index.md is generated as dist/index.html

[JP] 主な変更点
- tiny_http を用いた最小構成の静的サーバ（serve コマンド）を追加
- URL とファイルの対応（/, /foo/, /foo/index.html）を実装
- content/index.md を dist/index.html に出力するよう修正

---

## Motivation / Purpose / 目的
[EN]
Serving generated files via HTTP is necessary to correctly test routing and directory-based URLs.
The previous output structure (dist/index/index.html) prevented the root URL (/) from working as expected.

[JP]
ディレクトリベースの URL を正しく確認するためには HTTP 経由での配信が必要でした。
従来の dist/index/index.html という構造では / でトップページが表示されなかったため、出力仕様を修正しています。

---

## How to Test / 動作確認方法
[EN] Steps to verify the behavior  
1.  Run `oxidepress build --clean`
2.  Run `oxidepress serve`
3. Open `http://127.0.0.1:3000/` in a browser

[JP] 動作確認手順
1. oxidepress build --clean を実行
2. oxidepress serve を実行
3. ブラウザで http://127.0.0.1:3000/ を開く

---

## Related Issue / 関連 Issue
- Closes #1

---

## Additional Notes / 補足
[EN] This is a minimal implementation intended as a foundation for future features such as watch mode and live reload.
[JP] 本実装は最小構成（MVP）であり、今後 watch や Live Reload などの拡張を前提としています。
