### PR TITLE
Feature/3 toml front matter

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -200,7 +200,11 @@ const DEFAULT_PAGE_HTML: &str = r#"<!doctype html>
 </html>
 "#;
 
-const DEFAULT_INDEX_MD: &str = r#"# Hello oxidepress
+const DEFAULT_INDEX_MD: &str = r#"+++
+title = "Hello oxidepress"
++++
+
+# Hello oxidepress
 
 It works.
 "#;

--- a/src/site/mod.rs
+++ b/src/site/mod.rs
@@ -6,6 +6,7 @@ use walkdir::WalkDir;
 
 use crate::config::Config;
 use crate::error::Result;
+use crate::site::page::{infer_title, parse_front_matter};
 
 pub use page::Page;
 
@@ -37,6 +38,7 @@ impl Site {
 
             let markdown = fs::read_to_string(path)?;
             let rel = path.strip_prefix(&cfg.content_dir).unwrap_or(path);
+            let (meta, body_markdown) = parse_front_matter(&markdown)?;
 
             // 例: content/blog/a.md -> dist/blog/a/index.html （SSGっぽいURL）
             let output_path = to_output_path(&cfg.output_dir, rel);
@@ -45,8 +47,12 @@ impl Site {
                 // source: path.to_path_buf(),
                 route: rel.to_path_buf(),
                 output_path,
-                title: page::infer_title(&markdown, rel),
-                markdown,
+                title: meta
+                    .title
+                    .clone()
+                    .unwrap_or_else(|| infer_title(&body_markdown, rel)),
+                meta,
+                markdown: body_markdown,
             });
         }
 

--- a/src/site/page.rs
+++ b/src/site/page.rs
@@ -1,12 +1,58 @@
 use std::path::PathBuf;
 
+use serde::{Deserialize, Serialize};
+
+use crate::error::Result;
+
 #[derive(Debug, Clone)]
 pub struct Page {
     // pub source: PathBuf,
     pub route: PathBuf,
     pub output_path: PathBuf,
     pub title: String,
+    pub meta: PageMeta,
     pub markdown: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct PageMeta {
+    pub title: Option<String>,
+    pub draft: Option<bool>,
+    pub tags: Option<Vec<String>>,
+    pub date: Option<String>,
+}
+
+pub fn parse_front_matter(markdown: &str) -> Result<(PageMeta, String)> {
+    let mut lines = markdown.lines();
+    let Some(first) = lines.next() else {
+        return Ok((PageMeta::default(), String::new()));
+    };
+    if first.trim_end() != "+++" {
+        return Ok((PageMeta::default(), markdown.to_string()));
+    }
+
+    let mut toml_lines = Vec::new();
+    let mut found_end = false;
+    for line in lines.by_ref() {
+        if line.trim_end() == "+++" {
+            found_end = true;
+            break;
+        }
+        toml_lines.push(line);
+    }
+
+    if !found_end {
+        return Ok((PageMeta::default(), markdown.to_string()));
+    }
+
+    let toml_str = toml_lines.join("\n");
+    let meta = if toml_str.trim().is_empty() {
+        PageMeta::default()
+    } else {
+        toml::from_str(&toml_str)?
+    };
+    let body = lines.collect::<Vec<_>>().join("\n");
+    Ok((meta, body))
 }
 
 pub fn infer_title(markdown: &str, fallback_route: &std::path::Path) -> String {


### PR DESCRIPTION
## Title / タイトル
<!-- Example: [BUG] Fix crash on startup -->

---

## Overview / 概要
[EN] Adds TOML front matter support for Markdown pages under `content_dir`, extracting metadata into `PageMeta` and stripping it from the body. Title resolution now prefers `meta.title` over the first H1 and filename fallback.
[JP] content_dir 配下の Markdown に TOML Front Matter（`+++ ... +++`）を追加できるようにし、`PageMeta` へ取り込みつつ本文から除去します。タイトル決定は `meta.title` を最優先し、次に H1、最後にファイル名をフォールバックとします。

---

## Type / 種類
- Feature

---

## Changes / 変更内容
[EN] List key changes  
None
[JP] 主な変更点
- `PageMeta`（title/draft/tags/date）を導入し、`Page` に `meta: PageMeta` を保持
- `parse_front_matter()` を追加し、Markdown先頭が `+++` の場合に次の `+++` までをTOMLとしてパース、本文から除去
- `Site::from_fs()` で `(meta, body_markdown)` を取得して Page を構築
- タイトル決定優先順位を `meta.title` → 最初の `# 見出し` → ファイル名 に変更

---

## Motivation / Purpose / 目的
[EN] Inferring titles only from the first Markdown H1 is limiting. Front matter enables explicit titles and future metadata (draft/tags/date) without changing templates or file paths.
[JP] Markdownの最初の `# 見出し` だけでタイトルを推定する方式は柔軟性に欠けます。Front Matter により title/draft/tags/date などのメタ情報を明示でき、テンプレートやファイルパスを変えずに将来拡張が可能になります。

---

## How to Test / 動作確認方法
[EN] Steps to verify the behavior  
None
[JP] 動作確認手順

1.  `content_dir` 配下にテスト用Markdownを作成（例：`content/test.md`）
```md
+++
title = "Front Matter Title"
draft = true
tags = ["rust", "ssg"]
date = "2026-01-26"
+++

# H1 Title

Body text

```
2.  ビルド/実行して `Site::from_fs()` がこのページを読み込むことを確認
3. 生成された `Page` の内容を確認
    - `page.meta.title == Some("Front Matter Title")`
    - `page.title == "Front Matter Title"`（H1より優先）
    - `page.markdown` に `+++ ... +++` ブロックが含まれていない（本文から除去）
4. Front MatterなしのMarkdownも用意して、従来通り H1 → ファイル名フォールバックでタイトルが決まることを確認

---

## Related Issue / 関連 Issue
- Closes #3

---

## Additional Notes / 補足
[EN] `parse_front_matter()` is designed to fail-soft: if the file does not start with `+++` or the closing delimiter is missing, it returns default meta and the original markdown unchanged.
[JP] `parse_front_matter()` はフェイルソフト設計で、先頭が `+++` でない場合や終端 `+++` が見つからない場合は、`PageMeta::default()` と元のMarkdownをそのまま返します。
